### PR TITLE
build: add support for Travis CI & SonarQube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,205 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+.tox/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+cmake-build-release/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-v][a-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
     - python: "3.6"
       env: TOXENV=cover
       language: python
+    - python: "3.7-dev"
+      env: TOXENV=py37
+      os: linux
+      language: python
   allow_failures:
     - python: "3.7-dev"
       env: TOXENV=py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,13 @@ matrix:
       env: TOXENV=py36
       os: osx
       language: generic
+    - python: "3.6"
+      env: TOXENV=cover
+      language: python
+  allow_failures:
     - python: "3.7-dev"
       env: TOXENV=py37
       os: linux
-      language: python
-    - python: "3.6"
-      env: TOXENV=cover
       language: python
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+matrix:
+  include:
+    - python: "3.6"
+      env: TOXENV=py36
+      os: linux
+      language: python
+    - python: "3.6"
+      env: TOXENV=py36
+      os: osx
+      language: generic
+    - python: "3.7-dev"
+      env: TOXENV=py37
+      os: linux
+      language: python
+    - python: "3.6"
+      env: TOXENV=cover
+      language: python
+
+addons:
+  sonarcloud:
+    organization: mrtimscampi-github
+
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then virtualenv venv -p python3; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source venv/bin/activate; fi
+
+install:
+  - pip install tox-travis coveralls
+
+script:
+  - tox
+  - if [ "$TOXENV" == "cover" ]; then sonar-scanner; fi;
+
+after_success: |
+  if [ "$TOXENV" == "cover" ]; then coveralls; fi;
+
+# TODO: Automatically release to GitHub when we push a Git Tag.
+#deploy:
+#  provider: releases
+#  api_key:
+#    secure: JRGPq74zBteiRbnKxVet1dsCoue0z6lyGvQkLbVsTaAj8QCwupfQUlD3LTVnIZGa7K2GDnSyrx4rhv+y2rUyJPumMnXp0BGzOKb5nCz8BnQohKYvKpTHoZ31s3aRX03uC5FgIJo6wuGkDiDV3R91Pt0DJgXJhbagCB8gR91IUsAgkY8UKqbd1ANZAA26EQYwPzBG8QiuHoGhjTDIMu8Uxn9zpjfbB2vJN/AQz0JkPjsluXPXPpTnWpJSfsSeobogxx66ZxKJUazECTxhZ4gKu8TK67nr0w5I44tBL2CvNmBZNRoNeZFPEgd+zEdoGc9HBUPKiep6g5ObM+sGbNaIjRm87RrrAWHCwOAI+q8c9zAcUrMjCuwTI95e8FZRk2nT7QEmb0N0ENKNvsR6D80u98BVpxN6PezGrRMMxGgQ+qEMneO8xPqZK0Jp6JAPidom+tc9JEbfeRRAO1V5GSTsthgg/OG/257dlIqKX6hStNVzgsWXSbO9Tte4tijPJKE++cvyjjW0hlLSAs8pwomV36zAMOQl6KCnU+Q7q8TYjf7stuDKUgNA8RdaPaMfhgOTDW6QHw0aK4Bf3sgFZXhMZvsSjHFAvfQPe+nYj6BQvQHANIkb3+7QAIhzK5gYVYDuLJyI09X5gvWwTJ/MGyVqF8QSNX0/bJ4aAPZ0o+r/sx0=
+#  on:
+#    tags: true
+
+sudo: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include epigraf/_version.py
+include README.rst

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     author='Julien Machiels',
     author_email='iamtimscampi@gmail.com',
-    packages=['epigraf', 'epigraf.test'],
+    packages=['epigraf'],
     license='LICENSE.txt',
     description='Next-generation file management for data hoarders.',
-    long_description=open('README.txt').read(),
+    long_description=open('README.rst').read(),
     install_requires=[
         'PyQt5',],
 )

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=MrTimscampi:epigraf
+sonar.sources=epigraf

--- a/tests/test_mainwindow.py
+++ b/tests/test_mainwindow.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def test_boolean():
+    assert True
+    assert not False

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+[tox]
+envlist = py36, py37, flake8, cover
+
+[testenv]
+passenv = TRAVIS TRAVIS_*
+deps=
+    pytest
+    pytest-cov
+    pytest-pep8
+    pytest-qt
+    PyQt5
+commands =
+    py.test -v
+
+[testenv:flake8]
+deps =
+    flake8
+commands =
+    flake8 epigraf tests
+
+[travis]
+python =
+    3.6: py36, flake8
+    3.7: py37, flake8
+
+[pytest]
+addopts =
+    --ignore=setup.py
+
+    --cov epigraf
+python_files = *.py
+python_functions = test_
+
+[cover]
+passenv = TRAVIS TRAVIS_*
+deps=
+    pytest
+    pytest-cov
+    pytest-pep8
+    pytest-qt
+    PyQt5
+commands =
+    py.test -v
+    coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -26,13 +26,12 @@ python =
 [pytest]
 addopts =
     --ignore=setup.py
-
     --cov epigraf
 python_files = *.py
 python_functions = test_
 
 [cover]
-passenv = TRAVIS TRAVIS_*
+passenv = TRAVIS TRAVIS_*e
 deps=
     pytest
     pytest-cov

--- a/versioneer.py
+++ b/versioneer.py
@@ -209,7 +209,7 @@ Versioneer-0.16 and earlier only looked for a `.git` directory next to the
 
 `setup.py develop` and `pip install --editable .` allow you to install a
 project into a virtualenv once, then continue editing the source code (and
-test) without re-installing after every change.
+tests) without re-installing after every change.
 
 "Entry-point scripts" (`setup(entry_points={"console_scripts": ..})`) are a
 convenient way to specify executable scripts that should be installed along


### PR DESCRIPTION
This adds automated testing and building using Travis CI, as well as code quality and coverage reporting using SonarQube.

This is a base and should be supplemented in further commits.